### PR TITLE
Automatically refresh the page, once.

### DIFF
--- a/disable-time-travel-mode/disable-time-travel-mode.user.js
+++ b/disable-time-travel-mode/disable-time-travel-mode.user.js
@@ -11,6 +11,7 @@
 // @match       *://*.serverfault.com/*
 // @match       *://*.askubuntu.com/*
 // @match       *://*.stackapps.com/*
+// @match       *://*.mathoverflow.net/*
 // @exclude     *://api.stackexchange.com/*
 // @exclude     *://blog.*.com/*
 // @exclude     *://chat.*.com/*
@@ -18,12 +19,22 @@
 // @exclude     *://elections.stackexchange.com/*
 // @exclude     *://openid.stackexchange.com/*
 // @exclude     *://stackexchange.com/*
+// @run-at      document-start
 // @grant       none
-// @version     0.2
+// @version     0.3
 // ==/UserScript==
 
 (function () {
   "use strict";
-  $.cookie("tm2019", "1", { expires: 2, path: '/' });
-  $.cookie("tm2019d", "1", { expires: 2, path: '/' });
+  if (Date.now() < 1554335999000) {
+    //Don't do anything if April Fools 2019 is past.
+    if (document.cookie.indexOf('glorObeyUserPref') === -1 && (document.cookie.indexOf('tm2019') === -1 || document.cookie.indexOf('tm2019d') === -1)) {
+      //We only want to set these once, so the user can turn the 2019 April Fools theme on for a site, if they want.
+      //Using a cookie for our own flag automatically cleans up for us after April Fools Day.
+      document.cookie = 'glorObeyUserPref=1;path=/;expires=Wed, 03 Apr 2019 23:59:59 GMT';
+      document.cookie = 'tm2019=1;path=/;expires=Wed, 03 Apr 2019 23:59:59 GMT';
+      document.cookie = 'tm2019d=1;path=/;expires=Wed, 03 Apr 2019 23:59:59 GMT';
+      window.location.reload(false);
+    }
+  }
 })()


### PR DESCRIPTION
* The cookies are set once per domain. This allows the user to enable the April Fools mode, if they want.
* @run-at document-start, so TM & VM users don't need to wait for the page to load for the auto-refresh.
* Change to using vanilla JavaScript, as Greasemonkey 4 doesn't obey any @run-at settings (even the nominal default) and will have this run anywhere from document-start (i.e. prior to jQuery loading) to document-end.