### PR TITLE
Don't break layout

### DIFF
--- a/pronoun-assistant/pronoun-assistant.user.js
+++ b/pronoun-assistant/pronoun-assistant.user.js
@@ -141,7 +141,7 @@ function showPronouns($element, pronouns) {
   if ($element.next("span.mod-flair").length != 0) {
     $element = $element.next("span.mod-flair");
   }
-  $element.after($('<span class="pronouns">' + pronouns + '</span>'));
+  $element.after($('<span class="pronouns"></span>').text(pronouns.replace(/<[^>]+>/g, '')));
 }
 
 // Check text (obtained from the user's 'about me' in their chat profile or Q&A profile) for pronoun indicators


### PR DESCRIPTION
Concatenating `pronouns` into the HTML string causes layout bugs, because there's an unclosed `<p>` in there that gets appended to the `.pronouns` element, which forces a line break after the pronouns and before the timestamp on a comment. (It's also _technically_ an XSS, but there's protection for that because the content comes from the SE API, which sources from already-sanitized data.) This PR fixes that by using `$().text` to force everything in `pronouns` to be `text/plain` rather than potential HTML, and by removing any HTML tags in the string.

Needs version bumping before release.