### PR TITLE
Fix line breaks in the middle of pronouns

### DIFF
--- a/pronoun-assistant/pronoun-assistant.user.js
+++ b/pronoun-assistant/pronoun-assistant.user.js
@@ -48,7 +48,7 @@ GM_addStyle(`
   color: #777;
 }
 .pronouns {
-  padding-left: 5px;
+  word-break: keep-all;
 }
 .pronouns a:hover {
   text-decoration: underline;
@@ -136,7 +136,7 @@ function addPronounsToChatSignatures($element, pronouns) {
   // The element might contain both a tiny and a full signature
   $element.find("div.username").each(function (index, usernameElement) {
     usernameElement.innerHTML = '<span class="name">' + usernameElement.innerHTML + '</span><br/>'
-      + '<span class="pronouns">' + pronouns + '</span>';
+      + '<span class="pronouns"> ' + pronouns + '</span>';
   });
 }
 


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/10406565/67341660-246b0080-f528-11e9-8c16-8f52c1e16971.png)

by using a simple space instead of padding, and forcing the line break after the pronouns.

