### PR TITLE
Proper margins when notice shown below

### DIFF
--- a/post-notice-repositioner/post-notice-repositioner.user.js
+++ b/post-notice-repositioner/post-notice-repositioner.user.js
@@ -33,6 +33,8 @@
       target = $(this).parent().parent().siblings("div.js-post-notices");
     }
     $(this).remove();
+	  $(this).removeClass("mb16");
+	  $(this).addClass("my8");
     target.append($(this));
   });
 })();


### PR DESCRIPTION
Remove the `margin-bottom:16` that had been applied to the notice, and add top and bottom margins of 8px. Looks better that way