### PR TITLE
Fix post menu CSS selector

### DIFF
--- a/mathjax-network-overview-generator/mathjax-network-overview-generator.user.js
+++ b/mathjax-network-overview-generator/mathjax-network-overview-generator.user.js
@@ -68,7 +68,7 @@
   }
   
   // Add post menu button
-  let menu = $("#answer-216607").find('div.post-menu');
+  let menu = $("#answer-216607").find('div.js-post-menu');
   menu.append($('<span class="lsep">|</span>'));
   let button = $('<a href="#">update</a>');
   menu.append(button);


### PR DESCRIPTION
It seems the selector for the post menu has changed; this updates it so that the userscript can locate the post menu and properly insert itself again.