### PR TITLE
SoLS: Fix inability to detect if question is closed

### DIFF
--- a/saviour-of-lost-souls/saviour-of-lost-souls.user.js
+++ b/saviour-of-lost-souls/saviour-of-lost-souls.user.js
@@ -151,9 +151,9 @@ function buttonClicked(question) {
   let score = parseInt(question.find('div.js-vote-count')[0].innerText.replace(/,/g, ''));
 
   // Closed?
-  let status = question.find('aside.s-notice p.mb0.mt6');
+  let status = question.find('aside.s-notice b');
   let statusText = status.length > 0 ? status[0].innerText : '';
-  let closed = statusText.startsWith('Closed');
+  let closed = statusText == 'Closed.';
 
   // Analyze comments
   let comments = question.find('ul.comments-list');


### PR DESCRIPTION
A recent change made by SE has a portion of the post notice design that changes the way that the Saviour of Lost Souls script detects whether a question is closed or not. This change (provided [by you, to be clear](https://chat.meta.stackexchange.com/transcript/message/9210571#9210571), not my code!) resolves that problem.