### PR TITLE
made explicit that you're on Meta ...

### DIFF
--- a/saviour-of-lost-souls/saviour-of-lost-souls.user.js
+++ b/saviour-of-lost-souls/saviour-of-lost-souls.user.js
@@ -283,9 +283,9 @@ function createDialog(question) {
           "This site is for mathematicians to ask each other questions about their research. Please have a look at [math.se] to ask general mathematics questions. " +
           "Check [How to ask a good question](https://math.meta.stackexchange.com/q/9959/228959) to make sure your post is in good shape. " +
           "Your question is definitely [off-topic](/help/on-topic) and better deleted here.")
-       : ("Hi " + author + ", welcome to Meta! " +
+       : ("Hi " + author + ", welcome to the Stack Exchange Network Meta site! " +
           "I'm not sure which search brought you here but the problem you describe will not be answered on this specific site. " +
-          "To get an answer from users that have the expertise about the topic of your question you'll have to find and then re-post on the [proper site](https://stackexchange.com/sites). " +
+          "To get an experts answer for the topic of your question you'll have to find and then re-post on the [proper site](https://stackexchange.com/sites). " +
           "Check [How do I ask a good question](/help/how-to-ask) and [What is on topic](/help/on-topic) on the *target* site to make sure your post is in good shape. " +
           "Your question is definitely off-topic on [Meta](/help/whats-meta) and is better deleted here.");
       $.post({


### PR DESCRIPTION
... the Stack Exchange Meta that is. The characters lost for extending that text, were gained in the "To get an answer" sentence

context: https://chat.meta.stackexchange.com/transcript/message/9274029#9274029