### PR TITLE
Reworded to work with all meta sites

### DIFF
--- a/saviour-of-lost-souls/saviour-of-lost-souls.user.js
+++ b/saviour-of-lost-souls/saviour-of-lost-souls.user.js
@@ -283,7 +283,7 @@ function createDialog(question) {
           "This site is for mathematicians to ask each other questions about their research. Please have a look at [math.se] to ask general mathematics questions. " +
           "Check [How to ask a good question](https://math.meta.stackexchange.com/q/9959/228959) to make sure your post is in good shape. " +
           "Your question is definitely [off-topic](/help/on-topic) and better deleted here.")
-       : ("Hi " + author + ", welcome to the Stack Exchange Network Meta site! " +
+       : ("Hi " + author + ", welcome to our Meta site! " +
           "I'm not sure which search brought you here but the problem you describe will not be answered on this specific site. " +
           "To get an expert's answer for the topic of your question you'll have to find and then re-post on the [proper site](https://stackexchange.com/sites). " +
           "Check [How do I ask a good question](/help/how-to-ask) and [What is on topic](/help/on-topic) on the *target* site to make sure your post is in good shape. " +


### PR DESCRIPTION
It currently says "welcome to the Stack Exchange Network Meta site" on all meta sites, which can be a little confusing. Changed to "welcome to our Meta site" to make it meaningful on child metas too.