### PR TITLE
Restrict revisions button to show appropriately

### DIFF
--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -8,7 +8,7 @@
 // @updateURL   https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @downloadURL https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @supportURL  https://stackapps.com/questions/9611/openai-detector
-// @version     0.8
+// @version     0.8.1
 // @match       *://*.askubuntu.com/*
 // @match       *://*.mathoverflow.net/*
 // @match       *://*.serverfault.com/*
@@ -156,7 +156,7 @@
     }
 
     // Revisions - only attach button to revisions that have a "Source" button. Do not attach to tag only edits.
-    $("a[href$='/view-source']").each(function() {
+    $(".js-revisions a[href$='/view-source']").each(function() {
       const sourceButton = $(this);
 
       // Add button


### PR DESCRIPTION
If any link on the page ends in `/view-source` then the "Detect OpenAI" button shows up.

Instead now matching links in the top section of a revision markup.

---

See report here: https://stackapps.com/a/9637

The indiscriminate match of links that end in `view-source` was over-eager. It should now match only if a revision is shown. The markup makes it inconvenient to match for "Link button in the heading of a revision" but I think the selector chosen is adequate. It gets the first div in an element with a class "js-revision". 

Here is the structure of the HTML for the revisions page for reference: 

```html
<div class="js-revisions">
 <!-- omitted -->
  <div class="mb12 js-revision">
    <div class="d-flex p4 ai-center gs4 bg-powder-100">
      <div class="flex--item">
        <button type="button" class="s-btn s-btn__unset c-pointer js-revision-expander" data-controller="s-expandable-control" aria-expanded="true" aria-controls="rev-body-00000000-0000-0000-0000-000000000000" data-guid="00000000-0000-0000-0000-000000000000" data-is-loaded="true">
          <div class="d-flex ai-center py8 gs8 gsx fc-black-600 md:fd-column-reverse">
            <div class="flex--item">
              <svg aria-hidden="true" class="js-off-icon d-none svg-icon iconArrowRightAlt" width="18" height="18" viewBox="0 0 18 18">
                <path d="M6.41 2 5 3.41 10.59 9 5 14.59 6.41 16l7-7-7-7Z"></path>
              </svg>
              <svg aria-hidden="true" class="js-on-icon svg-icon iconArrowDownAlt" width="18" height="18" viewBox="0 0 18 18">
                <path d="m16.01 7.43-1.4-1.41L9 11.6 3.42 6l-1.4 1.42 7 7 7-7Z"></path>
              </svg>
            </div>
            <div class="flex--item w48 fs-headline1 fw-bold ta-left md:ta-center" title="revision 1">1</div>
          </div>
        </button>
      </div>
      <div class="flex--item fl1 wmn1">
        <div class="d-flex ai-center fw-wrap">
          <div class="flex--item">
            <span class="js-revision-comment"></span>
          </div>
        </div>
        <div class="d-flex gs8 s-anchors s-anchors__muted fw-wrap pt8">
          <a href="/revisions/00000000-0000-0000-0000-000000000000/view-source" class="flex--item" title="view raw text of this revision" target="_blank">Source</a>
          <a href="/revisions/0000/1" class="flex--item" title="link to this formatted revision">Link</a>
          <button type="button" class="flex--item s-btn s-btn__link js-full-link d-none">
            Full
          </button>
        </div>
        <div class="d-none md:d-block mt8">
          <!-- user details - omitted-->
        </div>
      </div>
	  <!-- other details - omitted-->
     </div>
    <div id="rev-body-00000000-0000-0000-0000-000000000000" class="s-expandable is-expanded" style="clip-path: none !important;">
      <!-- body of the post - omitted-->
	</div>
  </div>
</div>
```

An alternative to matching the exact elements would be to watch out for which page it is and load or not load the code, however, that might still be brittle if a body of a post happens to include a link which ends in `/view-source`. Also, I am not entirely sure if there are other pages where revisions are shown. If so, this code should work on them as well, without requiring explicit whitelisting. As long as the HTML structure matches what looks like a revision, the button will be added.