### PR TITLE
OpenAI detector: use event target

### DIFF
--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -8,7 +8,7 @@
 // @updateURL   https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @downloadURL https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @supportURL  https://stackapps.com/questions/9611/openai-detector
-// @version     0.10
+// @version     0.11
 // @match       *://*.askubuntu.com/*
 // @match       *://*.mathoverflow.net/*
 // @match       *://*.serverfault.com/*

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -61,7 +61,7 @@
     }
 
     function receiveOpenAIDetectionDataForButton(event) {
-      const button = $(event.originalTarget);
+      const button = $(event.target);
       if (!isMS) {
         StackExchange.helpers.removeSpinner(button);
       }
@@ -182,7 +182,7 @@
   function receiveRequestForDataFromPage(event) {
     const text = JSON.parse(event.detail);
     detectAI(text).then((jsonData) => {
-      event.originalTarget.dispatchEvent(new CustomEvent('OAID-receive-detection-data', {
+      event.target.dispatchEvent(new CustomEvent('OAID-receive-detection-data', {
         bubbles: true,
         cancelable: true,
         detail: jsonData,


### PR DESCRIPTION
This switches from using `Event.originalTarget`, which is Firefox only, to `Event.target`, which is the normal and  compatible way to access the target element and should have been used to begin with.

This fixes one of two issues which were identified by @double-beep in comments on PR #39. It should be, by far, the issue that impacts more people. I'll submit a PR for the switch to using the SE API in a while, as it's a bit more involved.