### PR TITLE
OpenAI detector: Use SE API to get post Markdown

### DIFF
--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -56,6 +56,30 @@
   function inPage() {
     const isMS = window.location.hostname === 'metasmoke.erwaysoftware.com';
 
+    /**
+     * Extracts and prepates just the post text ignoring notices.
+     * @param {jQuery} post - container where the body can be found as a child
+     * @return {string} text to analyse
+     */
+    function extractPostText(post) {
+      const postBody = post.find(".js-post-body").clone();
+      //remove post notices
+      postBody.find("aside").remove();
+
+      return cleanText(postBody.text());
+    }
+
+    /**
+     * Try to clean text for handing over to the detector.
+     * @param {string} text - content of a post
+     * @return {string} a cleaned version of the post with newlines removed
+     */
+    function cleanText(text) {
+      return text
+        .trim()
+        .replace(/\n/g, " ");
+    }
+
     function updateButtonTextWithPercent(button, percent) {
       button.text(button.text().replace(/(?: \(\d+(?:\.\d+)?%\)$|$)/, ` (${percent}%)`));
     }

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -126,9 +126,6 @@
 
     function requestOpenAIDetectionDataForButton(button, text) {
       button.blur();
-      if (!isMS) {
-        StackExchange.helpers.addSpinner(button);
-      }
       button[0].dispatchEvent(new CustomEvent('OAID-request-detection-data', {
         bubbles: true,
         cancelable: true,
@@ -306,6 +303,7 @@
 
     function handlePostMenuButtonClick() {
       const button = $(this);
+      StackExchange?.helpers?.addSpinner(button);
       const postMenu = button.closest("div.js-post-menu");
       const shareLink = postMenu.find('.js-share-link').first();
       const shareUrl = shareLink[0].href;
@@ -410,6 +408,7 @@
           menu.append(button);
 
           button.on('click', function() {
+            StackExchange?.helpers?.addSpinner(button);
             const linkURL = sourceButton.attr("href");
             $.get(linkURL, function(result) {
               const sourcePage = new DOMParser().parseFromString(result, "text/html");

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -8,7 +8,7 @@
 // @updateURL   https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @downloadURL https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @supportURL  https://stackapps.com/questions/9611/openai-detector
-// @version     0.11
+// @version     0.12
 // @match       *://*.askubuntu.com/*
 // @match       *://*.mathoverflow.net/*
 // @match       *://*.serverfault.com/*

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -156,26 +156,28 @@
         addButtonToAllPostMenus();
         setTimeout(addButtonToAllPostMenus, 175); // SE uses a 150ms animation for SE.realtime.reloadPosts(). This runs after that.
       });
-    }
 
-    // Revisions - only attach button to revisions that have a "Source" button. Do not attach to tag only edits.
-    $(".js-revision > div:nth-child(1) a[href$='/view-source']").each(function() {
-      const sourceButton = $(this);
+      if (/^\/posts\/\d+\/revisions/.test(window.location.pathname)) {
+        // Revisions - only attach button to revisions that have a "Source" button. Do not attach to tag only edits.
+        $(".js-revision > div:nth-child(1) a[href$='/view-source']").each(function() {
+          const sourceButton = $(this);
 
-      // Add button
-      const button = $('<button type="button" class="flex--item s-btn s-btn__link" title="detect OpenAI">Detect OpenAI</button>');
-      const menu = sourceButton.parent();
-      menu.append(button);
+          // Add button
+          const button = $('<button type="button" class="flex--item s-btn s-btn__link" title="detect OpenAI">Detect OpenAI</button>');
+          const menu = sourceButton.parent();
+          menu.append(button);
 
-      button.on('click', function() {
-        const linkURL = sourceButton.attr("href");
-        $.get(linkURL, function(result) {
-          const sourcePage = new DOMParser().parseFromString(result, "text/html");
-          const text = sourcePage.body.textContent.trim();
-          requestOpenAIDetectionDataForButton(button, text);
+          button.on('click', function() {
+            const linkURL = sourceButton.attr("href");
+            $.get(linkURL, function(result) {
+              const sourcePage = new DOMParser().parseFromString(result, "text/html");
+              const text = sourcePage.body.textContent.trim();
+              requestOpenAIDetectionDataForButton(button, text);
+            });
+          });
         });
-      });
-    });
+      }
+    }
   }
   makyenUtilities.executeInPage(inPage, true, 'OpenAI-detector-page-script');
 


### PR DESCRIPTION
This PR does:
* Changes getting post data to:
  1. Markdown text from SE API
  2. If that fails (e.g. deleted post), then the Markdown text from `/posts/${postId}/edit-inline` is used.
  3. If that fails (e.g. deleted post with pending edit; possible, at least briefly), the currently displayed HTML is used.
* Adds a cache for post and revision Markdown source, so the data isn't re-fetched each time the button is clicked. The cache is only for the current page/tab and isn't shared between tabs. The cache is currently not invalidated when an edit is made to the post, so a page reload will be needed in such cases.
* When one post on a page is to be tested, the post Markdown for all posts listed in the page (up to 100) is fetched from the SE API at once and the Markdown stored in the cache, so additional requests of the SE API aren't needed. Obviously, this won't include any deleted posts, as no data for deleted posts is available from the SE API.
* The SE API is not used for revisions, because the SE API doesn't provide the option to get Markdown text for post revisions.
* Changes all `\r\n` in post revisions and HTML to `\n`, as that can result in differences in the detection percentage. ([identified by cigien in chat](https://chat.stackoverflow.com/transcript/250149?m=56018585#56018585))
* Shows the spinner immediately after the user clicks the button, rather than after getting the source text.