### PR TITLE
OpenAI Detector: add iframe in-page

### DIFF
--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -407,7 +407,7 @@
       event.preventDefault();
       const button = $(this);
       const tabContent = button.closest("div.post-body-panel-markdown");
-      const postMarkdown = tabContent.children(".post-body-pre-block").html();
+      const postMarkdown = tabContent.children(".post-body-pre-block").text();
       requestOpenAIDetectionDataForButton(button, postMarkdown);
     }
 

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -431,11 +431,15 @@
     }
 
     function handlePostMenuButtonClick(event) {
-      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+      if (event.shiftKey || event.ctrlKey || event.metaKey) {
         return;
       }
-      event.preventDefault();
       const button = $(this);
+      if (event.altKey) {
+        // Go directly to opening iframe
+        button.addClass('SEOAID-button-has-been-clicked');
+      }
+      event.preventDefault();
       const postMenu = button.closest("div.js-post-menu");
       const shareLink = postMenu.find('.js-share-link').first();
       const shareUrl = shareLink[0].href;
@@ -483,11 +487,15 @@
     }
 
     function handleMSMarkdownButtonClick() {
-      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+      if (event.shiftKey || event.ctrlKey || event.metaKey) {
         return;
       }
-      event.preventDefault();
       const button = $(this);
+      if (event.altKey) {
+        // Go directly to opening iframe
+        button.addClass('SEOAID-button-has-been-clicked');
+      }
+      event.preventDefault();
       const tabContent = button.closest("div.post-body-panel-markdown");
       const postMarkdown = tabContent.children(".post-body-pre-block").text();
       if (addIframeIfButtonClicked(button, 'after', button.closest('.SEOAID-Markdown-button-cntainer'), button.closest('.post-body-panel-markdown.SEOAID-markdown-button-added'), () => Promise.resolve(postMarkdown))) {
@@ -555,11 +563,15 @@
     }
 
     function handleRevisionButtonClick(event) {
-      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+      if (event.shiftKey || event.ctrlKey || event.metaKey) {
         return;
       }
-      event.preventDefault();
       const button = $(this);
+      if (event.altKey) {
+        // Go directly to opening iframe
+        button.addClass('SEOAID-button-has-been-clicked');
+      }
+      event.preventDefault();
       const sourceUrl = button.data('sourceUrl');
       const [site, revisionId] = getSeApiSiteParamAndPostIdOrRevisionIdFromUrl(sourceUrl, true);
       verifySiteCacheExists(site);

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -516,10 +516,19 @@
     // The GM polyfill doesn't convert GM_xmlhttpRequest to a useful Promise in all userscript managers (i.e. Violentmonkey), so...
     const gmXmlhttpRequest = typeof GM_xmlhttpRequest === 'function' ? GM_xmlhttpRequest : GM.xmlHttpRequest;
     const baseURL = "https://openai-openai-detector.hf.space/openai-detector";
+    const fullURL = `${baseURL}?${encodeURIComponent(text)}`;
+    // Restrict the length of OAI API request URLs to prevent 414 Request URI Too Long errors
+    let maxCharacters = 16400;
+    if (fullURL[maxCharacters - 1] === '%') {
+      maxCharacters--;
+    }
+    if (fullURL[maxCharacters - 2] === '%') {
+      maxCharacters -= 2;
+    }
     return new Promise((resolve, reject) => {
       gmXmlhttpRequest({
         method: "GET",
-        url: `${baseURL}?${encodeURIComponent(text)}`,
+        url: fullURL.slice(0, maxCharacters),
         timeout: 60000, // There's no particular reason for this length, but don't want to hang forever.
         onload: resolve,
         onabort: reject,

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -357,26 +357,16 @@
     }
 
     function addSeoaidIframe(button, method, where, iframeAncestor, getText) {
-      where[method](`<div class="SEOID-iframe-container post-layout--right"><iframe sandbox="allow-same-origin allow-scripts" class="SEOAID-oaid-iframe" src="https://openai-openai-detector.hf.space/"></iframe></div>`);
+      where[method](`<div class="SEOID-iframe-container post-layout--right"><div class="SEOAID-iframe-close-button-container"><span class="SEOAID-iframe-close-button" title="close this GPT-2 Output Detector Demo iframe">×</span></div><iframe sandbox="allow-same-origin allow-scripts" class="SEOAID-oaid-iframe" src="https://openai-openai-detector.hf.space/"></iframe></div>`);
       button.addClass('SEOAID-iframe-open SEOAID-iframe-created');
       const iframe = iframeAncestor.find('.SEOAID-oaid-iframe');
       const iframeContainer = iframeAncestor.find('.SEOID-iframe-container');
       const iframeContainerHeightStorageKey = 'SEOAID-iframeContainer-height';
-      iframe.css({
-        border: 'unset',
-        'width': '100%',
-      });
       // CSS resize doesn't work on iframes in Firefox
       iframeContainer.css({
-        resize: 'vertical',
-        'overflow-y': 'auto',
         height: localStorage[iframeContainerHeightStorageKey] || '770px',
-        border: '2px solid #333',
-        'margin-top': '10px',
-        'padding-right': '0px',
-        'margin-right': 'var(--su16)',
-        display: 'flex',
       });
+      iframeContainer.find('.SEOAID-iframe-close-button-container').on('click', () => button.click());
       let iframeHeightDebounceTimer = null;
       const resizeObserver = new ResizeObserver(() => {
         clearTimeout(iframeHeightDebounceTimer);
@@ -952,6 +942,39 @@ h1 {
       return;
   }
 
+  document.documentElement.insertAdjacentHTML('beforeend', `<style id="SEOAID-styles-for-in-page-iframe">
+/* Styles for in page iframe */
+.SEOAID-oaid-iframe {
+  border: unset;
+  width: 100%;
+}
+.SEOID-iframe-container {
+  resize: vertical;
+  overflow-y: auto;
+  border: 2px solid #333;
+  margin-top: 10px;
+  padding-right: 0px;
+  margin-right: var(--su16);
+  display: flex;
+  position: relative;
+}
+.SEOAID-iframe-close-button-container {
+  position: absolute;
+  top: 8px;
+  right: 4px;
+  cursor: pointer;
+}
+.SEOAID-iframe-close-button {
+  /* These are copied from SE's popup close button. */
+  padding: 3px 6px 2px;
+  font-size: var(--fs-body3);
+  font-weight: normal;
+  color: hsl(0,0%,100%) !important;
+  background-color: hsl(210,8%,5%);
+  font-family: Arial,Helvetica,sans-serif;
+  line-height: 1;
+}
+</style>`);
   makyenUtilities.executeInPage(inSEorMSPage, true, 'OpenAI-detector-page-script');
 
   function receiveRequestForDataFromPage(event) {

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -793,8 +793,8 @@ h1 {
   gap: 5px;
 }
 .SEOAID-request-truncated #message::after {
-	content: " (request text truncated)";
-	color: red;
+  content: " (request text truncated)";
+  color: red;
 }
 </style>`);
     if (window !== window.top) {
@@ -843,7 +843,7 @@ h1 {
               document.body.classList.add('SEOAID-have-received-text');
               setTextAndTriggerPrediction(textToTest);
             }
-					}
+          }
         }
       });
       window.top.postMessage({

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -8,7 +8,7 @@
 // @updateURL   https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @downloadURL https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/openai-detector/openai-detector.user.js
 // @supportURL  https://stackapps.com/questions/9611/openai-detector
-// @version     0.12
+// @version     0.13
 // @match       *://*.askubuntu.com/*
 // @match       *://*.mathoverflow.net/*
 // @match       *://*.serverfault.com/*

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -46,14 +46,14 @@
    * context.  The GM.xmlHttpRequest() function is only available in that context, not in
    * the page context.  Most of this script relies on jQuery and access to the StackExchange
    * Object.  Both of those are in the page context.  So, most of the script, everything in
-   * the inPage() function, is placed in the page context.  For the page context to get the
+   * the inSEorMSPage() function, is placed in the page context.  For the page context to get the
    * detection data, an event, "SEOAID-request-detection-data", is dispatched with the text to
    * pass to the OpenAI detector on the button which has been clicked.  Once the data is
    * received, the "SEOAID-receive-detection-data" event is dispatched with the data received
    * from the OpenAI Detector.
   */
 
-  function inPage() {
+  function inSEorMSPage() {
     const cache = {};
     const SE_API_CONSTANTS = {
       key: 'b4pJgQpVylPHom5vj811QQ((',
@@ -498,7 +498,7 @@
       }
     }
   }
-  makyenUtilities.executeInPage(inPage, true, 'OpenAI-detector-page-script');
+  makyenUtilities.executeInPage(inSEorMSPage, true, 'OpenAI-detector-page-script');
 
   function receiveRequestForDataFromPage(event) {
     const text = JSON.parse(event.detail);

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -647,8 +647,9 @@
       return button;
     }
 
-    function setTextAndTriggerPrediction(text) {
+    function setTextAndTriggerPrediction(text, retainCurrentInsertOffset) {
       const textbox = document.getElementById('textbox');
+      const origSelectionEnd = textbox.selectionEnd || 0;
       textbox.select();
       try {
         // This will put the replacement in the textbox's "undo" stack.
@@ -659,6 +660,10 @@
       if (textbox.value !== text) {
         console.error('In inOpenAIDetectorPage: textbox.value !== text: textbox.value:', {'textbox.value': textbox.value}, '\n:: text:', {text});
         textbox.value = text;
+      }
+      if (retainCurrentInsertOffset) {
+        // This isn't perfect, but it's probably closer to what a user expects.
+        textbox.selectionEnd = origSelectionEnd;
       }
       textbox.dispatchEvent(new InputEvent('input'));
     }
@@ -754,7 +759,7 @@
     const headerContainer = document.querySelector('.SEOAID-header-container');
     const headerButtonContainer = document.querySelector('.SEOAID-header-button-container');
     headerContainer.prepend(header);
-    headerButtonContainer.append(createButton('Restore text', 'SEOAID-restore-text-button', () => setTextAndTriggerPrediction(receivedText)));
+    headerButtonContainer.append(createButton('Restore text', 'SEOAID-restore-text-button', () => setTextAndTriggerPrediction(receivedText, true)));
     headerButtonContainer.insertAdjacentHTML('beforeend', '<span class="SEOAID-strip-buttons-wrap"><span class="SEOAID-strip-buttons-text"></span><span class="SEOAID-strip-buttons-container"></span></span>');
     const stripButtonsWrap = headerButtonContainer.querySelector('.SEOAID-strip-buttons-wrap');
     const stripButtonsText = stripButtonsWrap.querySelector('.SEOAID-strip-buttons-text');
@@ -763,22 +768,22 @@
     stripButtonsContainer.append(createButton('links', 'SEOAID-strip-links-button', () => {
       const textbox = document.getElementById('textbox');
       const initialText = textbox.value;
-      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, linkRegexes, true).trim());
+      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, linkRegexes, true).trim(), true);
     }));
     stripButtonsContainer.append(createButton('links and link text', 'SEOAID-strip-links-and-link-text-button', () => {
       const textbox = document.getElementById('textbox');
       const initialText = textbox.value;
-      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, linkRegexes).trim());
+      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, linkRegexes).trim(), true);
     }));
     stripButtonsContainer.append(createButton('code blocks', 'SEOAID-strip-code blocks-button', () => {
       const textbox = document.getElementById('textbox');
       const initialText = textbox.value;
-      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, null, codeBlockRegexes).trim());
+      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, null, codeBlockRegexes).trim(), true);
     }));
     stripButtonsContainer.append(createButton('HTML comments', 'SEOAID-strip-HTML-comments-button', () => {
       const textbox = document.getElementById('textbox');
       const initialText = textbox.value;
-      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, /<!--.*?-->/g).trim());
+      setTextAndTriggerPrediction(regexRemovalsWithProtection(initialText, codeBlockRegexes, /<!--.*?-->/g).trim(), true);
     }));
 
     document.documentElement.insertAdjacentHTML('beforeend', `<style id="SEOAID-styles">
@@ -890,7 +895,7 @@ h1 {
             if (typeof textToTest === 'string') {
               receivedText = textToTest;
               document.body.classList.add('SEOAID-have-received-text');
-              setTextAndTriggerPrediction(textToTest);
+              setTextAndTriggerPrediction(textToTest, true);
             }
           }
         }

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -352,7 +352,7 @@
     }
 
     function addSeoaidIframe(button, method, where, iframeAncestor, getText) {
-      where[method]('<iframe class="SEOAID-oaid-iframe post-layout--right" src="https://openai-openai-detector.hf.space/"></iframe>');
+      where[method](`<iframe sandbox="allow-same-origin allow-scripts" class="SEOAID-oaid-iframe post-layout--right" src="https://openai-openai-detector.hf.space/"${notShow ? ' style="display: none;"' : ''}></iframe>`);
       button.addClass('SEOAID-iframe-open SEOAID-iframe-created');
       const iframe = iframeAncestor.find('.SEOAID-oaid-iframe');
       iframe.css({

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -47,9 +47,9 @@
    * the page context.  Most of this script relies on jQuery and access to the StackExchange
    * Object.  Both of those are in the page context.  So, most of the script, everything in
    * the inPage() function, is placed in the page context.  For the page context to get the
-   * detection data, an event, "OAID-request-detection-data", is dispatched with the text to
+   * detection data, an event, "SEOAID-request-detection-data", is dispatched with the text to
    * pass to the OpenAI detector on the button which has been clicked.  Once the data is
-   * received, the "OAID-receive-detection-data" event is dispatched with the data received
+   * received, the "SEOAID-receive-detection-data" event is dispatched with the data received
    * from the OpenAI Detector.
   */
 
@@ -122,11 +122,11 @@
       }
       updateButtonTextWithPercent(button, percent);
     }
-    window.addEventListener('OAID-receive-detection-data', receiveOpenAIDetectionDataForButton);
+    window.addEventListener('SEOAID-receive-detection-data', receiveOpenAIDetectionDataForButton);
 
     function requestOpenAIDetectionDataForButton(button, text) {
       button.blur();
-      button[0].dispatchEvent(new CustomEvent('OAID-request-detection-data', {
+      button[0].dispatchEvent(new CustomEvent('SEOAID-request-detection-data', {
         bubbles: true,
         cancelable: true,
         detail: JSON.stringify(text),
@@ -491,14 +491,14 @@
   function receiveRequestForDataFromPage(event) {
     const text = JSON.parse(event.detail);
     detectAI(text).then((jsonData) => {
-      event.target.dispatchEvent(new CustomEvent('OAID-receive-detection-data', {
+      event.target.dispatchEvent(new CustomEvent('SEOAID-receive-detection-data', {
         bubbles: true,
         cancelable: true,
         detail: jsonData,
       }));
     });
   }
-  window.addEventListener('OAID-request-detection-data', receiveRequestForDataFromPage);
+  window.addEventListener('SEOAID-request-detection-data', receiveRequestForDataFromPage);
 
   function detectAI(text) {
     // The GM polyfill doesn't convert GM_xmlhttpRequest to a useful Promise in all userscript managers (i.e. Violentmonkey), so...

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -349,7 +349,11 @@
         });
     }
 
-    function handlePostMenuButtonClick() {
+    function handlePostMenuButtonClick(event) {
+      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+      event.preventDefault();
       const button = $(this);
       StackExchange?.helpers?.addSpinner(button);
       const postMenu = button.closest("div.js-post-menu");
@@ -383,7 +387,7 @@
       // Regular posts
       const menu = $(this);
       // Add button
-      const button = $('<button class="s-btn s-btn__link SEOAID-post-menu-button" type="button" href="#">Detect OpenAI</button>');
+      const button = $('<a class="SEOAID-post-menu-button" href="https://openai-openai-detector.hf.space/" title="Run the post content through the Hugging Face GPT-2 Output Detector.">Detect OpenAI</button>');
       const cell = $('<div class="flex--item SEOAID-post-menu-item"></div>');
       cell.append(button);
       menu.children().first().append(cell);
@@ -397,6 +401,10 @@
     }
 
     function handleMSMarkdownButtonClick() {
+      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+      event.preventDefault();
       const button = $(this);
       const tabContent = button.closest("div.post-body-panel-markdown");
       const postMarkdown = tabContent.children(".post-body-pre-block").html();
@@ -407,7 +415,7 @@
       // Regular posts
       const tabContent = $(this);
       // Add button
-      const button = $('<button class="SEOAID-markdown-button" type="button" href="#">Detect OpenAI</button>');
+      const button = $('<a class="SEOAID-markdown-button" href="https://openai-openai-detector.hf.space/" title="Run the post content through the Hugging Face GPT-2 Output Detector.">Detect OpenAI</a>');
       const cell = $('<div class="SEOAID-Markdown-button-cntainer"></div>');
       cell.append(button);
       tabContent.append(cell);
@@ -439,7 +447,11 @@
         });
     }
 
-    function handleRevisionButtonClick() {
+    function handleRevisionButtonClick(event) {
+      if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+        return;
+      }
+      event.preventDefault();
       const button = $(this);
       StackExchange?.helpers?.addSpinner(button);
       const sourceUrl = button.data('sourceUrl');
@@ -475,7 +487,7 @@
         $(".js-revision > div:nth-child(1) a[href$='/view-source']").each(function() {
           const sourceButton = $(this);
           // Add button
-          const button = $('<button type="button" class="flex--item s-btn s-btn__link" title="detect OpenAI">Detect OpenAI</button>');
+          const button = $('<a class="flex--item" title="Run the revision content through the Hugging Face GPT-2 Output Detector." href="https://openai-openai-detector.hf.space/">Detect OpenAI</a>');
           const sourceUrl = sourceButton[0].href;
           const menu = sourceButton.parent();
           menu.append(button);

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -644,6 +644,7 @@
     function setTextAndTriggerPrediction(text, retainCurrentInsertOffset) {
       const textbox = document.getElementById('textbox');
       const origSelectionEnd = textbox.selectionEnd || 0;
+      const origScrollTop = textbox.scrollTop || 0;
       textbox.select();
       try {
         // This will put the replacement in the textbox's "undo" stack.
@@ -658,6 +659,15 @@
       if (retainCurrentInsertOffset) {
         // This isn't perfect, but it's probably closer to what a user expects.
         textbox.selectionEnd = origSelectionEnd;
+        // A setTimeout here is needed.  If the textbox.scrollTop is not delayed, then it's
+        // ineffective, at least in Firefox.
+        // The process does result in a flash movement, but the disruption is minimal and it
+        // does end up mostly where it was.  If we wanted to get fancy, we'd determine how
+        // much of the text is being changed prior to the insert and scroll locations and
+        // adjust the values based on that.
+        setTimeout(() => {
+          textbox.scrollTop = origScrollTop;
+        }, 0);
       }
       textbox.dispatchEvent(new InputEvent('input'));
     }

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -363,8 +363,8 @@
       const iframeContainer = iframeAncestor.find('.SEOID-iframe-container');
       const iframeContainerHeightStorageKey = 'SEOAID-iframeContainer-height';
       iframe.css({
-        width: '100%',
-        height: 'calc(100% - 4px)',
+        border: 'unset',
+        'flex-basis': '100%',
       });
       // CSS resize doesn't work on iframes in Firefox
       iframeContainer.css({
@@ -372,7 +372,10 @@
         'overflow-y': 'auto',
         height: localStorage[iframeContainerHeightStorageKey] || '770px',
         border: '2px solid #333',
-        margin: '10px',
+        'margin-top': '10px',
+        'padding-right': '0px',
+        'margin-right': 'var(--su16)',
+        display: 'flex',
       });
       let iframeHeightDebounceTimer = null;
       const resizeObserver = new ResizeObserver(() => {

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -613,7 +613,17 @@
 
     function setTextAndTriggerPrediction(text) {
       const textbox = document.getElementById('textbox');
-      textbox.value = text;
+      textbox.select();
+      try {
+        // This will put the replacement in the textbox's "undo" stack.
+        document.execCommand("insertText", false, text);
+      } catch (error) {
+        textbox.value = text;
+      }
+      if (textbox.value !== text) {
+        console.error('In inOpenAIDetectorPage: textbox.value !== text: textbox.value:', {'textbox.value': textbox.value}, '\n:: text:', {text});
+        textbox.value = text;
+      }
       textbox.dispatchEvent(new InputEvent('input'));
     }
 

--- a/openai-detector/openai-detector.user.js
+++ b/openai-detector/openai-detector.user.js
@@ -60,7 +60,7 @@
     const SE_API_CONSTANTS = {
       key: 'b4pJgQpVylPHom5vj811QQ((',
       posts: {
-        filter: '!3yXujnEzOWHFVt)rv',
+        filter: '38FD8bVlOlsmcYi8', // This is an "unsafe" filter.
         state: 'PublishedAndStagingGround', // Currently only valid on /posts and /questions
         pagesize: 100,
       },


### PR DESCRIPTION
This PR, again, ended up substantially larger than initially intended. Primarily, it adds the ability to open an iframe to the GPT-2 Output Detector Demo page below the post or revision the user is viewing and populates the textbox with the text from the post or revision. There's also quite a bit of additional associated functionality.

This PR:
* "Detect OpenAI" buttons are changed to links, so the user can directly open the GPT-2 Output Detector Demo page, if desired.
* On Alt-click or the second click of the "Detect OpenAI" button an iframe is opened below the post or revision to the GPT-2 Output Detector Demo page.
  * The textbox is populated with the text from the post or revision.
  * Several buttons are provided which perform transformations of the text. Each transformation is added to the textbox undo stack, so the user can use the normal textbox undo/redo:
    * "Restore text": restores the prepopulated text
    * Several buttons which strip content from the textbox:
      * links
      * links & link text
      * code blocks
      * HTML comments
      * code fences
      * Markdown code indents
      * inline code format
      * bold & italics
    * Additional clicks on the "Detect OpenAI" button toggle visibility of the iframe, which can also be closed with a close button.
    * User can resize the height of both the iframe and textbox. Both user-selected heights are persistent.
    * iframe content is responsive
* Also runs on the base GPT-2 Output Detector Demo page
  * No text is pre-populated, but that's planned for a future release.
  * The same buttons as in the iframe (above) are provided, but the "restore text" button is not displayed due to not pre-populating any text.
  * The request to the Hugging Face API is intercepted and corrected:
    * The query portion of the URL is encoded with `encodeURIComponent()`. The page not properly encoding the URL was causing various detection errors and % FAKE discrepancies.
    * The URL is limited to 16,400 characters. If the URL is longer than that, then the HF API returns an error.
  * The page is made responsive for narrower width screens/viewports.
* The length of the URL for our requests to the HF API is also limited to 16,400 characters. More than that produces an error.
* Code consistency: Change all OAID to SEOAID on identifiers in the code. I believe SEOAID was the original and I, mistakenly, used OAID in earlier contributions, which made things inconsistent.
* Use an "unsafe" SE API filter to get the Markdown in order to avoid a double-encoding bug in the SE API. See: "[SE API multiple-escapes the returned data (at least display names, userlinks, and post content)](https://meta.stackexchange.com/q/387761/271271)"