### PR TITLE
add more neopronouns

### DIFF
--- a/pronoun-assistant/pronoun-assistant.user.js
+++ b/pronoun-assistant/pronoun-assistant.user.js
@@ -61,7 +61,8 @@ let allPronouns = [
   "she", "her?", // that covers 'he' as well
   "they", "them", "their",
   "ze", "hir", "zir",
-  "xey", "xem", "xyr"
+  "xey?", "xem", "xyr",
+  "faer?"
 ].join("|");
 let pronounListRegex = new RegExp('\\W*((' + allPronouns + ')(\\s*/\\s*(' + allPronouns + '))+)\\W*', 'i');
 let myPronounIsRegex = /(https?:\/\/)?(my\.)?pronoun\.is\/([\w/]+)/i;


### PR DESCRIPTION
In my experience (in general, not just on stackexchange), xe/xem and fae/faer are the most widely-used neopronouns. However, they aren't recognized by the pronoun assistant userscript, despite the fact that some other neopronouns are. This PR adds them.