### PR TITLE
Chat link in dropdown script: Fix appearance issue with terminated anchor

### DIFF
--- a/add-network-profile-link/add-network-profile-link.user.js
+++ b/add-network-profile-link/add-network-profile-link.user.js
@@ -88,7 +88,7 @@
         chatName = 'stackexchangemeta';
         break;
     }
-    const chatLogo = `<div class="favicon favicon-${chatName}" title="Chat site favicon"/>`;
+    const chatLogo = `<div class="favicon favicon-${chatName}" title="Chat site favicon"></div>`;
     const chatLink = `${location.protocol}//${chatHost}/${(chatID !== -1) ? 'account' : 'users'}/${chatID}`;
 
     // If the profile page uses a dropdown, insert link to chat profile as the first item in the list;


### PR DESCRIPTION
There's a style issue in the dropdown for the chat profile link.

![](https://i.imgur.com/HhHGrn4.png)

It seems that attempting to terminate the div for the favicon using `/>` actually terminates the anchor element early. This change explicitly terminates the icon div using `</div>` instead, fixing the appearance issue.

![](https://i.imgur.com/OjRVjc6.png)

Rendered HTML for the list item prior to this change:

```html
<li role="menuitem">
<a class="s-block-link d-flex ai-center ws-nowrap" href="https://chat.stackoverflow.com/account/15484767"></a><div class="favicon favicon-stackoverflow" title="Chat site favicon"><a class="s-block-link d-flex ai-center ws-nowrap" href="https://chat.stackoverflow.com/account/15484767"><div class="ml4">Chat profile</div></a></div>
</li>
```

After:

```html
<li role="menuitem">
<a class="s-block-link d-flex ai-center ws-nowrap" href="https://chat.stackoverflow.com/account/15484767"><div class="favicon favicon-stackoverflow" title="Chat site favicon"></div><div class="ml4">Chat profile</div></a>
</li>
```

Dunno why it works exactly, but it does. :P