### PR TITLE
Exempt Answer Bot and exclude SEDE

### DIFF
--- a/add-network-profile-link/add-network-profile-link.user.js
+++ b/add-network-profile-link/add-network-profile-link.user.js
@@ -5,6 +5,7 @@
 // @author      Glorfindel
 // @contributor Spevacus
 // @contributor Cody Gray
+// @contributor gparyani
 // @updateURL   https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/add-network-profile-link/add-network-profile-link.user.js
 // @downloadURL https://raw.githubusercontent.com/Glorfindel83/SE-Userscripts/master/add-network-profile-link/add-network-profile-link.user.js
 // @supportURL  https://stackapps.com/q/9328
@@ -21,6 +22,7 @@
 // @exclude     *://chat.stackexchange.com/users/*
 // @exclude     *://chat.stackoverflow.com/users/*
 // @exclude     *://chat.meta.stackexchange.com/users/*
+// @exclude     *://data.stackexchexchange.com/users/*
 // @grant       none
 // ==/UserScript==
 /* globals $:readonly, StackExchange:readonly */
@@ -40,7 +42,8 @@
     const userID = StackExchange.user?.options?.userId;
     const chatID = StackExchange.user?.options?.accountId;
     if ((typeof(userID) === 'undefined') ||
-        (typeof(chatID) === 'undefined')) return;
+        (typeof(chatID) === 'undefined') ||
+        userID < -1 || chatID < -1) return;
 
     // Check if link to the network profile is already present.
     const user = $("#mainbar-full.user-show-new");


### PR DESCRIPTION
Exempt users with negative IDs except the Community user from linking, as their user IDs clash with other chat users. This currently affects the Answer Bot, which has a user ID of -2 but no network profile and no chat profile (chat ID -2 is Feeds).

Also, SEDE doesn't have the page attributes in question, so exclude it.